### PR TITLE
feat: omit cloud details

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -146,9 +146,11 @@ export async function activate(context: ExtensionContext): Promise<void> {
     }
     item.detail = args.entry.detail ? args.entry.detail : args.detailMessage
     let detail = item.detail || ''
-    if (detail == DEFAULT_DETAIL
-      || detail.indexOf('TabNine::sem') != -1
-      || detail.indexOf('Buy a license') != -1) {
+    if (detail == DEFAULT_DETAIL || [
+        'Buy a license',
+        'TabNine Cloud',
+        'TabNine::sem',
+      ].some(str => detail.includes(str))) {
       delete item.detail
     }
     if (item.detail == null && item.insertTextFormat != InsertTextFormat.Snippet) {


### PR DESCRIPTION
This omits cloud details from the suggestion, keeping the completion
menu narrow in width.