### PR TITLE
Omit Deep TabNine details

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -148,6 +148,7 @@ export async function activate(context: ExtensionContext): Promise<void> {
     let detail = item.detail || ''
     if (detail == DEFAULT_DETAIL || [
         'Buy a license',
+        'Deep TabNine',
         'TabNine Cloud',
         'TabNine::sem',
       ].some(str => detail.includes(str))) {


### PR DESCRIPTION
The TabNine version 2.0.5 changed the text for details. Deep TabNine
specific details include "Deep TabNine" and TabNine Cloud specific
"TabNine Cloud". Both details are, in our case, unwanted as it makes the
complete menu very wide.
