### PR TITLE
Fix the naming of option disable_filetypes

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -30,7 +30,7 @@ Use command `:CocConfig` to open user configuration file of coc.nvim.
 - _"tabnine.shortcut"_: Shortcut for tabnine source., default: `"TN"`
 - _"tabnine.triggers"_: Trigger characters of TabNine source, default: `[]`
 - _"tabnine.priority"_: Priority of tabnine source., default: `100`
-- _"tabnine.disable_filetyps"_: Disable TabNine with configured filetypes., default: `[]`
+- _"tabnine.disable_filetypes"_: Disable TabNine with configured filetypes., default: `[]`
 - _"tabnine.disable_line_regex"_: Disable TabNine when the current line contains a match of any of the provided regexes. For example, add "require" to disable TabNine when the current line contains the word 'require'., default: `[]`
 - "tabnine.disable_file_regex": Disable TabNine when the file path contains a match of any of the provided regexes. For example, add "[.]js\$" to disable TabNine in JavaScript files., default: `[]`
 

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
           "default": null,
           "description": "Priority of tabnine source, use priority of languageserver by default."
         },
-        "tabnine.disable_filetyps": {
+        "tabnine.disable_filetypes": {
           "type": "array",
           "default": [],
           "description": "Disable TabNine with configured filetypes."

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,7 +24,7 @@ export async function activate(context: ExtensionContext): Promise<void> {
   await TabNine.installTabNine(binaryRoot)
 
   let priority = configuration.get<number>('priority', undefined)
-  let disable_filetyps = configuration.get<string[]>('disable_filetyps', [])
+  let disable_filetypes = configuration.get<string[]>('disable_filetypes', [])
   let limit = configuration.get<number>('limit', 10)
 
   subscriptions.push(commands.registerCommand('tabnine.openConfig', async () => {
@@ -49,7 +49,7 @@ export async function activate(context: ExtensionContext): Promise<void> {
 
   subscriptions.push(languages.registerCompletionItemProvider('tabnine', configuration.get<string>('shortcut', 'TN'), null, {
     async provideCompletionItems(document: TextDocument, position: Position, token: CancellationToken, context: CompletionContext): Promise<CompletionList | undefined | null> {
-      if (disable_filetyps.indexOf(document.languageId) !== -1) return null
+      if (disable_filetypes.indexOf(document.languageId) !== -1) return null
       let { option } = context as any
       try {
         const offset = document.offsetAt(position)


### PR DESCRIPTION
The option to disable filetypes are currently `disable_filetyps`. This PR simply fixes the spelling error.