### PR TITLE
Use correct path for binary and updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
-lib
 binaries
+lib
+node_modules


### PR DESCRIPTION
TabNine changed their paths for linux from 'unknown-linux-gnu' ->
'unknown-linux-musl'. This commit also include minor changes to make the
code more DRY.

This fixes the https://github.com/neoclide/coc-tabnine/issues/18 issue.