### PR TITLE
fix: cleanup after failed download

### DIFF
--- a/src/download.ts
+++ b/src/download.ts
@@ -1,9 +1,10 @@
-import { http, https } from 'follow-redirects'
 import fs from 'fs'
-import { Agent, RequestOptions } from 'http'
 import mkdirp from 'mkdirp'
 import path from 'path'
 import tunnel from 'tunnel'
+import rimraf from 'rimraf'
+import { Agent, RequestOptions } from 'http'
+import { http, https } from 'follow-redirects'
 import { parse } from 'url'
 import { workspace } from 'coc.nvim'
 
@@ -37,43 +38,51 @@ export default function download(url: string, dest: string, onProgress: (msg: nu
   if (!dest || !path.isAbsolute(dest)) {
     throw new Error(`Expect absolute file path for dest option.`)
   }
-  let folder = path.dirname(dest)
-  if (!fs.existsSync(folder)) mkdirp.sync(folder)
-  let endpoint = parse(url)
-  let mod = url.startsWith('https') ? https : http
-  let agent = getAgent(endpoint.protocol)
-  let opts: RequestOptions = {
+
+  const folder = path.dirname(dest)
+  const endpoint = parse(url)
+  const mod = url.startsWith('https') ? https : http
+  const agent = getAgent(endpoint.protocol)
+  const opts: RequestOptions = {
     method: 'GET',
     hostname: endpoint.hostname,
-    port: endpoint.port ? parseInt(endpoint.port, 10) : (endpoint.protocol === 'https:' ? 443 : 80),
+    port: endpoint.port ? parseInt(endpoint.port, 10) : endpoint.protocol === 'https:' ? 443 : 80,
     path: endpoint.path,
     protocol: url.startsWith('https') ? 'https:' : 'http:',
     agent,
     headers: {
       'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64)',
-      'Accept-Encoding': 'gzip'
-    }
+      'Accept-Encoding': 'gzip',
+    },
   }
+
+  if (!fs.existsSync(folder)) mkdirp.sync(folder)
+
   return new Promise<void>((resolve, reject) => {
     const req = mod.request(opts, res => {
       if (res.statusCode != 200) {
         reject(new Error(`Invalid response from ${url}: ${res.statusCode}`))
         return
       }
-      if (onProgress) {
-        const len = parseInt(res.headers['content-length'], 10)
-        let cur = 0
-        if (!isNaN(len)) {
+      if (onProgress != null) {
+        const contentLength = parseInt(res.headers['content-length'], 10)
+        let current = 0
+        if (!isNaN(contentLength)) {
           res.on('data', chunk => {
-            cur += chunk.length
-            onProgress(cur / len)
+            current += chunk.length
+            onProgress(current / contentLength)
           })
         }
       }
-      let stream = res.pipe(fs.createWriteStream(dest))
+
+      const stream = res.pipe(fs.createWriteStream(dest))
       stream.on('finish', resolve)
     })
     req.on('error', reject)
     req.end()
+  }).catch((err) => {
+    // Cleanup after failed download.
+    rimraf.sync(path.resolve(folder, '..'))
+    throw err
   })
 }


### PR DESCRIPTION
This should help in cases where the binary download somehow fails.
Removing all the assets for that specific version should allow
coc-tabnine to try to redownload once it is restarted. This solution is
far from fail-safe though as there is currently no way to validate, via
a hash or similar, if a binary is valid or not.

Related issues: #32, #26, #24, #6.