### PR TITLE
Add additional magic strings API Key note to readme

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -43,6 +43,12 @@ Use command `:CocConfig` to open user configuration file of coc.nvim.
 
 Configure TabNine itself by inputting a _magic string_ like `TabNine::config` or `TabNine::restart` in any buffer and trigger autocomplete. A full list of available _magic strings_ is available here: https://tabnine.com/faq/#magic_strings.
 
+### API Key
+
+This library does not configure Tabnine's Pro API key, if you've purchased a subscription license. To configure, you'll need to use the `TabNine::config` magic string to update your preferences. 
+
+> _Note: An API key is not required to use [`coc-tabnine`](#coc-tabine)._
+
 ## License
 
 MIT


### PR DESCRIPTION
Apologies for not filing a feature request issue but figured I'd save some time since what I suggest is a minor change to documentation.
 
I've simply added a minor update to the **Magic Strings** section of the readme concerning an API Key note for users, also noting that a key is not necessary. 

I use multiple editors so already have an API key and couldn't find a quick "where to put it" answer anywhere. 

If this isn't a priority I completely understand.